### PR TITLE
Répare l'export PNG en chargeant les DLL de QGIS

### DIFF
--- a/LOGICIEL.py
+++ b/LOGICIEL.py
@@ -305,12 +305,19 @@ def worker_run(args: Tuple[List[str], dict]) -> Tuple[int, int]:
         else ("minimal" if os.path.isfile(os.path.join(platform_dir, "qminimal.dll")) else "offscreen")
     os.environ["QT_QPA_PLATFORM"] = qpa
 
-    os.environ["PATH"] = os.pathsep.join([
+    bin_dirs = [
         os.path.join(qt_base, "bin"),
         os.path.join(cfg["QGIS_APP"], "bin"),
         os.path.join(cfg["QGIS_ROOT"], "bin"),
-        os.environ.get("PATH", ""),
-    ])
+    ]
+    os.environ["PATH"] = os.pathsep.join(bin_dirs + [os.environ.get("PATH", "")])
+
+    if hasattr(os, "add_dll_directory"):
+        for d in bin_dirs:
+            try:
+                os.add_dll_directory(d)
+            except FileNotFoundError:
+                pass
 
     sys.path.insert(0, os.path.join(cfg["QGIS_APP"], "python"))
     sys.path.insert(0, os.path.join(cfg["QGIS_ROOT"], "apps", cfg["PY_VER"], "Lib", "site-packages"))


### PR DESCRIPTION
## Résumé
- évite l'erreur `DLL load failed while importing _core` lors de l'export PNG
- ajoute la prise en charge de `os.add_dll_directory` pour que QGIS trouve ses bibliothèques

## Tests
- `python -m py_compile LOGICIEL.py id_contexte_eco.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad53d2330c832cb09867f10b2bf452