### PR TITLE
Corrige l’erreur de DLL lors de l’export des cartes

### DIFF
--- a/LOGICIEL.py
+++ b/LOGICIEL.py
@@ -305,12 +305,20 @@ def worker_run(args: Tuple[List[str], dict]) -> Tuple[int, int]:
         else ("minimal" if os.path.isfile(os.path.join(platform_dir, "qminimal.dll")) else "offscreen")
     os.environ["QT_QPA_PLATFORM"] = qpa
 
-    os.environ["PATH"] = os.pathsep.join([
+    path_entries = [
         os.path.join(qt_base, "bin"),
         os.path.join(cfg["QGIS_APP"], "bin"),
         os.path.join(cfg["QGIS_ROOT"], "bin"),
-        os.environ.get("PATH", ""),
-    ])
+    ]
+    os.environ["PATH"] = os.pathsep.join(path_entries + [os.environ.get("PATH", "")])
+
+    if hasattr(os, "add_dll_directory"):
+        for p in path_entries:
+            if os.path.isdir(p):
+                try:
+                    os.add_dll_directory(p)
+                except OSError:
+                    pass
 
     sys.path.insert(0, os.path.join(cfg["QGIS_APP"], "python"))
     sys.path.insert(0, os.path.join(cfg["QGIS_ROOT"], "apps", cfg["PY_VER"], "Lib", "site-packages"))


### PR DESCRIPTION
## Résumé
- gère correctement les dossiers de bibliothèques QGIS dans les processus d’export
- évite le message d’erreur `DLL load failed while importing _core`

## Test
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile LOGICIEL.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad60106220832cbe53107347ade31e