### PR TITLE
Corrige le chargement des DLL QGIS pour l'export de cartes

### DIFF
--- a/LOGICIEL.py
+++ b/LOGICIEL.py
@@ -312,6 +312,17 @@ def worker_run(args: Tuple[List[str], dict]) -> Tuple[int, int]:
         os.environ.get("PATH", ""),
     ])
 
+    if hasattr(os, "add_dll_directory"):
+        for p in (
+            os.path.join(qt_base, "bin"),
+            os.path.join(cfg["QGIS_APP"], "bin"),
+            os.path.join(cfg["QGIS_ROOT"], "bin"),
+        ):
+            try:
+                os.add_dll_directory(p)
+            except Exception:
+                pass
+
     sys.path.insert(0, os.path.join(cfg["QGIS_APP"], "python"))
     sys.path.insert(0, os.path.join(cfg["QGIS_ROOT"], "apps", cfg["PY_VER"], "Lib", "site-packages"))
 


### PR DESCRIPTION
## Résumé
- ajoute l'enregistrement explicite des dossiers QGIS pour permettre le chargement des DLL
- évite l'erreur `DLL load failed while importing _core` lors de l'export des cartes PNG

## Tests
- `python -m py_compile LOGICIEL.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad6012bcec832c982ebf3e2969a2bd