### PR TITLE
Corriger l'export des cartes en retardant l'import de l'analyse des zonages

### DIFF
--- a/LOGICIEL.py
+++ b/LOGICIEL.py
@@ -58,8 +58,6 @@ from docx.oxml.ns import qn
 
 from PIL import Image
 
-# Script d'identification des zonages
-from id_contexte_eco import run_analysis as run_id_context
 # Enregistrer le décodeur HEIF
 pillow_heif.register_heif_opener()
 
@@ -1432,6 +1430,7 @@ class IDContexteEcoTab(ttk.Frame):
         old_stdout = sys.stdout
         sys.stdout = self.stdout_redirect
         try:
+            from id_contexte_eco import run_analysis as run_id_context
             run_id_context(ae, ze)
             print("Analyse terminée.")
         except Exception as e:


### PR DESCRIPTION
## Résumé
- Évite l'import immédiat du module d'analyse des zonages pour rétablir l'environnement QGIS lors de l'export.
- Effectue l'import de `id_contexte_eco` uniquement au moment de l'analyse, comme dans l'ancienne version fonctionnelle.

## Tests
- ✅ `python -m py_compile LOGICIEL.py`
- ⚠️ `python - <<'PY'\nimport LOGICIEL\nPY` (module `requests` manquant dans l'environnement)


------
https://chatgpt.com/codex/tasks/task_e_68ad6500eea0832cb002bc877a405dac