### PR TITLE
Corrige l'export PNG en pointant vers l'interpréteur QGIS

### DIFF
--- a/LOGICIEL.py
+++ b/LOGICIEL.py
@@ -28,6 +28,7 @@ import shutil
 import tempfile
 import datetime
 import threading
+import multiprocessing
 import urllib.request
 import webbrowser
 import tkinter as tk
@@ -801,6 +802,8 @@ class ExportCartesTab(ttk.Frame):
 
             log_with_time(f"{len(projets)} projets (attendu = calcul en cours)")
             log_with_time(f"Workers={self.workers_var.get()}, DPI={self.dpi_var.get()}, marge={self.margin_var.get():.2f}, overwrite={self.overwrite_var.get()}")
+            qgis_python = os.path.join(QGIS_ROOT, "apps", PY_VER, "python.exe")
+            multiprocessing.set_executable(qgis_python)
 
             chunks = chunk_even(projets, self.workers_var.get())
             cfg = {


### PR DESCRIPTION
## Résumé
- utilise maintenant l'interpréteur Python installé avec QGIS pour lancer les workers
- évite les erreurs DLL lors de l'import des modules QGIS

## Tests
- `python -m py_compile LOGICIEL.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad6504dcf4832cb9985ed94a85db52