### PR TITLE
Permet de personnaliser le dossier des shapefiles via une variable d'environnement

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -82,8 +82,12 @@ SUBPATH    = r"Espace_RWO\CARTO ROBIN"
 
 OUT_IMG    = r"C:\Users\utilisateur\Mon Drive\1 - Bota & Travail\+++++++++  BOTA  +++++++++\---------------------- 3) BDD\PYTHON\2) Contexte éco\OUTPUT"
 
-# Dossier par défaut pour la sélection des shapefiles (onglet 1)
-DEFAULT_SHAPE_DIR = r"C:\Users\utilisateur\Mon Drive\1 - Bota & Travail\+++++++++  BOTA  +++++++++\---------------------- 2) CARTO terrain"
+# Dossier par défaut pour la sélection des shapefiles (onglet 1).
+# Peut être modifié en définissant la variable d'environnement CONTEXT_ECO_SHAPE_DIR.
+DEFAULT_SHAPE_DIR = os.environ.get(
+    "CONTEXT_ECO_SHAPE_DIR",
+    r"C:\Users\utilisateur\Mon Drive\1 - Bota & Travail\+++++++++  BOTA  +++++++++\---------------------- 2) CARTO terrain",
+)
 
 # QGIS
 QGIS_ROOT = r"C:\Program Files\QGIS 3.40.3"


### PR DESCRIPTION
## Résumé
- permet de changer le dossier par défaut des shapefiles grâce à la variable d'environnement `CONTEXT_ECO_SHAPE_DIR`

## Tests
- `python -m py_compile modules/main_app.py`
- `python -m py_compile Start.py modules/id_contexte_eco.py`


------
https://chatgpt.com/codex/tasks/task_e_68adaa03006c832cb491de8764a102eb