### PR TITLE
Accepter n'importe quel nom de shapefile pour l'ID contexte éco

### DIFF
--- a/modules/id_contexte_eco.py
+++ b/modules/id_contexte_eco.py
@@ -33,6 +33,18 @@ def log_with_time(message):
     print(f"[{now}] {message}")
 
 
+def to_long_unc(path: str) -> str:
+    """Retourne un chemin UNC long sous Windows pour accepter n'importe quel nom."""
+    path = os.path.abspath(path)
+    if os.name == 'nt':
+        if path.startswith('\\\\?\\'):
+            return path
+        if path.startswith('\\\\'):
+            return r"\\\\?\\UNC" + path[1:]
+        return r"\\\\?\\" + path
+    return path
+
+
 def run_analysis(ae_shp: str, ze_shp: str, buffer_km: float = 5.0):
     """Lance l'analyse d'identification des zonages à partir des shapefiles.
 
@@ -41,6 +53,10 @@ def run_analysis(ae_shp: str, ze_shp: str, buffer_km: float = 5.0):
     :param buffer_km: distance du tampon autour de la ZE en kilomètres
     """
     log_with_time("Démarrage du script d'identification des zonages...")
+
+    # Normaliser les chemins pour supporter tous les noms et chemins réseau
+    ae_shp = to_long_unc(ae_shp)
+    ze_shp = to_long_unc(ze_shp)
 
     # Vérifier si les fichiers de référence existent
     if not os.path.exists(ae_shp):

--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1431,11 +1431,15 @@ class IDContexteEcoTab(ttk.Frame):
             self.after(0, lambda: self.run_btn.config(state="normal"))
             return
 
+        # Normaliser les chemins pour éviter les erreurs liées aux noms ou à la longueur
+        ae_path = to_long_unc(ae)
+        ze_path = to_long_unc(ze)
+
         old_stdout = sys.stdout
         sys.stdout = self.stdout_redirect
         try:
             from .id_contexte_eco import run_analysis as run_id_context
-            run_id_context(ae, ze)
+            run_id_context(ae_path, ze_path)
             print("Analyse terminée.")
         except Exception as e:
             print(f"Erreur: {e}")
@@ -1739,11 +1743,15 @@ class ContexteEcoTab(ttk.Frame):
         t.start()
 
     def _run_id_logic(self, ae: str, ze: str, buffer_km: float):
+        # Normaliser les chemins avant de lancer l'analyse pour accepter tout nom de fichier
+        ae_path = to_long_unc(ae)
+        ze_path = to_long_unc(ze)
+
         old_stdout = sys.stdout
         sys.stdout = self.stdout_redirect
         try:
             from .id_contexte_eco import run_analysis as run_id_context
-            run_id_context(ae, ze, buffer_km)
+            run_id_context(ae_path, ze_path, buffer_km)
             log_with_time("Analyse terminée.")
             self.after(0, lambda: self.status_label.config(text="Terminé"))
         except Exception as e:


### PR DESCRIPTION
## Résumé
- normalisation des chemins vers les shapefiles pour éviter les erreurs liées aux noms
- utilisation des chemins normalisés avant de lancer l'analyse des zonages

## Tests
- `python -m py_compile modules/id_contexte_eco.py modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae905cc608832c8bec7ad46612bc91