### PR TITLE
Accepter tout nom de shapefile pour l'ID contexte éco

### DIFF
--- a/modules/id_contexte_eco.py
+++ b/modules/id_contexte_eco.py
@@ -33,6 +33,17 @@ def log_with_time(message):
     print(f"[{now}] {message}")
 
 
+def to_long_unc(path: str) -> str:
+    """Adapte le chemin pour Windows afin d'accepter les chemins longs."""
+    if os.name != "nt":
+        return path
+    if path.startswith("\\\\?\\"):
+        return path
+    if path.startswith("\\\\"):
+        return "\\\\?\\UNC" + path[1:]
+    return "\\\\?\\" + path
+
+
 def run_analysis(ae_shp: str, ze_shp: str, buffer_km: float = 5.0):
     """Lance l'analyse d'identification des zonages à partir des shapefiles.
 
@@ -42,13 +53,17 @@ def run_analysis(ae_shp: str, ze_shp: str, buffer_km: float = 5.0):
     """
     log_with_time("Démarrage du script d'identification des zonages...")
 
+    # Normaliser les chemins pour éviter les problèmes de longueur ou de réseau
+    ae_orig, ze_orig = ae_shp, ze_shp
+    ae_shp, ze_shp = to_long_unc(ae_shp), to_long_unc(ze_shp)
+
     # Vérifier si les fichiers de référence existent
     if not os.path.exists(ae_shp):
-        log_with_time(f"Le fichier de la première couche de référence n'a pas été trouvé : {ae_shp}")
+        log_with_time(f"Le fichier de la première couche de référence n'a pas été trouvé : {ae_orig}")
         return
 
     if not os.path.exists(ze_shp):
-        log_with_time(f"Le fichier de la deuxième couche de référence n'a pas été trouvé : {ze_shp}")
+        log_with_time(f"Le fichier de la deuxième couche de référence n'a pas été trouvé : {ze_orig}")
         return
 
     # Chargement des couches de référence

--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1719,7 +1719,9 @@ class ContexteEcoTab(ttk.Frame):
         ze = self.ze_shp_var.get().strip()
         if not ae or not ze:
             messagebox.showerror("Erreur", "Sélectionnez les deux shapefiles."); return
-        if not os.path.isfile(ae) or not os.path.isfile(ze):
+        def _exists(p):
+            return os.path.isfile(p) or (os.name == 'nt' and os.path.isfile(to_long_unc(p)))
+        if not _exists(ae) or not _exists(ze):
             messagebox.showerror("Erreur", "Un shapefile est introuvable."); return
 
         self.busy = True


### PR DESCRIPTION
## Résumé
- prise en charge de chemins longs Windows pour éviter l'obligation de nommer les shapefiles "zone etude" et "aire etude elargie"
- vérification d'existence des fichiers compatible UNC avant de lancer l'analyse

## Tests
- `python -m py_compile modules/id_contexte_eco.py modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae90616c84832c9c4d5363be7fb89a