### PR TITLE
Permettre le choix du dossier de sortie et l'export des projets QGIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ python Start.py
 
 L'application s'ouvrira avec plusieurs onglets proposant les fonctionnalités principales.
 
+## Export des cartes
+
+Dans l'onglet « Contexte éco », il est possible de choisir le dossier de sortie des exports. L'utilisateur peut sauvegarder seulement les images PNG, seulement les projets QGIS ou bien les deux. Les projets QGIS enregistrés gardent les chemins vers les shapefiles fournis par l'utilisateur.
+
 ## Structure du projet
 
 - `Start.py` : point d'entrée qui ouvre l'interface graphique.


### PR DESCRIPTION
## Résumé
- ajout d'un champ pour choisir le dossier où enregistrer les exports
- option pour exporter uniquement les PNG, uniquement les projets QGIS ou les deux
- sauvegarde des projets QGIS avec les chemins des shapefiles sélectionnés

## Tests
- `python -m py_compile modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae96c3cc9c832c9a40d0bebb37d4c0