### PR TITLE
Ajout choix dossier d'export et sauvegarde des projets QGIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ python Start.py
 
 L'application s'ouvrira avec plusieurs onglets proposant les fonctionnalités principales.
 
+L’onglet « Contexte éco » permet désormais de choisir le dossier d’export et d’y sauvegarder soit les images PNG des cartes, soit les projets QGIS, soit les deux.
+
 ## Structure du projet
 
 - `Start.py` : point d'entrée qui ouvre l'interface graphique.


### PR DESCRIPTION
## Résumé
- Permettre de choisir le dossier où seront enregistrés les résultats
- Option d'export des cartes en PNG, des projets QGIS ou des deux
- Les projets QGIS enregistrés reprennent les chemins des shapefiles sélectionnés

## Tests
- `python -m py_compile Start.py modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae96c69f18832c8dd9318e739e2736