### PR TITLE
Ajout d'extraits Wikipédia pour les communes

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1491,6 +1491,10 @@ class ContexteEcoTab(ttk.Frame):
         self.out_dir_var   = tk.StringVar(value=self.prefs.get("OUT_DIR", OUT_IMG))
         self.export_type_var = tk.StringVar(value=self.prefs.get("EXPORT_TYPE", "BOTH"))
 
+        # Variables pour les extraits Wikipédia
+        self.wiki_climat_var = tk.StringVar()
+        self.wiki_clc_var = tk.StringVar()
+
         self.project_vars: dict[str, tk.IntVar] = {}
         self.all_projects: List[str] = []
         self.filtered_projects: List[str] = []
@@ -1580,6 +1584,17 @@ class ContexteEcoTab(ttk.Frame):
         self.wiki_button = ttk.Button(idf, text="Wikipedia", style="Accent.TButton", command=self.start_wiki_thread)
         self.wiki_button.grid(row=0, column=3, sticky="w", padx=(12,0))
 
+        # Résultats Wikipédia
+        wikif = ttk.Frame(self, style="Card.TFrame", padding=12)
+        wikif.pack(fill=tk.X, pady=(10,0))
+        ttk.Label(wikif, text="Climat", style="Card.TLabel").grid(row=0, column=0, sticky="nw")
+        ttk.Label(wikif, textvariable=self.wiki_climat_var, style="Card.TLabel", wraplength=600, justify="left")\
+            .grid(row=0, column=1, sticky="w")
+        ttk.Label(wikif, text="Corine Land Cover", style="Card.TLabel").grid(row=1, column=0, sticky="nw", pady=(6,0))
+        ttk.Label(wikif, textvariable=self.wiki_clc_var, style="Card.TLabel", wraplength=600, justify="left")\
+            .grid(row=1, column=1, sticky="w", pady=(6,0))
+        wikif.columnconfigure(1, weight=1)
+
         # Console + progression
         bottom = ttk.Frame(self, style="Card.TFrame", padding=12)
         bottom.pack(fill=tk.BOTH, expand=True, pady=(10,0))
@@ -1660,6 +1675,8 @@ class ContexteEcoTab(ttk.Frame):
 
     def _run_wiki(self):
         try:
+            self.after(0, lambda: self.wiki_climat_var.set(""))
+            self.after(0, lambda: self.wiki_clc_var.set(""))
             ze_path = self.ze_shp_var.get()
             gdf = gpd.read_file(ze_path)
             if gdf.crs is None:
@@ -1674,15 +1691,15 @@ class ContexteEcoTab(ttk.Frame):
             if "error" in data:
                 print(f"[Wiki] {data['error']}", file=self.stdout_redirect)
             else:
+                self.after(0, lambda: self.wiki_climat_var.set(data.get("climat", "")))
+                self.after(0, lambda: self.wiki_clc_var.set(data.get("occupation", "")))
                 print(f"[Wiki] Page Wikipédia : {data['url']}", file=self.stdout_redirect)
                 print("[Wiki] CLIMAT :", file=self.stdout_redirect)
-                if data['climat_p1'] != 'Non trouvé':
-                    print(data['climat_p1'], file=self.stdout_redirect)
-                if data['climat_p2'] != 'Non trouvé':
-                    print(data['climat_p2'], file=self.stdout_redirect)
+                if data.get("climat") != "Non trouvé":
+                    print(data["climat"], file=self.stdout_redirect)
                 print("[Wiki] OCCUPATION DES SOLS :", file=self.stdout_redirect)
-                if data['occupation_p1'] != 'Non trouvé':
-                    print(data['occupation_p1'], file=self.stdout_redirect)
+                if data.get("occupation") != "Non trouvé":
+                    print(data["occupation"], file=self.stdout_redirect)
         except Exception as e:
             print(f"[Wiki] Erreur : {e}", file=self.stdout_redirect)
         finally:

--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -61,33 +61,25 @@ def _find_section_heading(soup: BeautifulSoup, heading_text: str):
 
 def _scrape_sections(driver: webdriver.Chrome) -> Dict[str, str]:
     out = {
-        "climat_p1": "Non trouvé",
-        "climat_p2": "Non trouvé",
-        "occupation_p1": "Non trouvé",
+        "climat": "Non trouvé",
+        "occupation": "Non trouvé",
     }
     soup = BeautifulSoup(driver.page_source, "html.parser")
 
     h = _find_section_heading(soup, "Climat")
     if h:
-        start = None
         for p in h.find_all_next("p"):
             t = p.get_text(strip=True)
-            if t.startswith("En 2010, le climat de la commune est de type") or "climat de la commune est de type" in t:
-                start = p
+            if t.startswith("Pour la période 1971-2000, la température annuelle"):
+                out["climat"] = t
                 break
-        if start:
-            fol = start.find_next_siblings("p", limit=2)
-            if len(fol) >= 1:
-                out["climat_p1"] = fol[0].get_text(strip=True)
-            if len(fol) >= 2:
-                out["climat_p2"] = fol[1].get_text(strip=True)
 
     h = _find_section_heading(soup, "Occupation des sols")
     if h:
         for p in h.find_all_next("p"):
             t = p.get_text(strip=True)
             if t.startswith("L'occupation des sols de la commune, telle qu'elle") or "L'occupation des sols de la commune, telle qu'elle ressort" in t:
-                out["occupation_p1"] = t
+                out["occupation"] = t
                 break
     return out
 
@@ -116,7 +108,9 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     except TimeoutException:
         pass
 
-    box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
+    box = WebDriverWait(driver, 0.5).until(
+        EC.element_to_be_clickable((By.ID, "searchInput"))
+    )
     box.clear()
     box.send_keys(query)
     box.send_keys(Keys.ENTER)


### PR DESCRIPTION
## Résumé
- Réduit le délai avant la saisie du nom de commune sur Wikipédia à 0,5 s
- Récupère les paragraphes sur le climat et l'occupation des sols depuis la page Wikipédia de la commune
- Affiche ces deux textes dans un petit tableau sous le bouton Wikipédia

## Tests
- `python -m py_compile modules/wikipedia_scraper.py modules/main_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeb9398cb4832c907b9e7bfa30446e