### PR TITLE
Affichage des infos climatiques et d'occupation des sols

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1490,6 +1490,8 @@ class ContexteEcoTab(ttk.Frame):
         self.buffer_var    = tk.DoubleVar(value=float(self.prefs.get("ID_TAMPON_KM", 5.0)))
         self.out_dir_var   = tk.StringVar(value=self.prefs.get("OUT_DIR", OUT_IMG))
         self.export_type_var = tk.StringVar(value=self.prefs.get("EXPORT_TYPE", "BOTH"))
+        self.wiki_climat_var = tk.StringVar(value="")
+        self.wiki_occupation_var = tk.StringVar(value="")
 
         self.project_vars: dict[str, tk.IntVar] = {}
         self.all_projects: List[str] = []
@@ -1580,6 +1582,14 @@ class ContexteEcoTab(ttk.Frame):
         self.wiki_button = ttk.Button(idf, text="Wikipedia", style="Accent.TButton", command=self.start_wiki_thread)
         self.wiki_button.grid(row=0, column=3, sticky="w", padx=(12,0))
 
+        wiki_frame = ttk.Frame(self, style="Card.TFrame", padding=12)
+        wiki_frame.pack(fill=tk.X, pady=(10,0))
+        wiki_frame.columnconfigure(1, weight=1)
+        ttk.Label(wiki_frame, text="Climat", style="Card.TLabel").grid(row=0, column=0, sticky="nw")
+        ttk.Label(wiki_frame, textvariable=self.wiki_climat_var, wraplength=600, style="Card.TLabel").grid(row=0, column=1, sticky="w")
+        ttk.Label(wiki_frame, text="Corine Land Cover", style="Card.TLabel").grid(row=1, column=0, sticky="nw", pady=(8,0))
+        ttk.Label(wiki_frame, textvariable=self.wiki_occupation_var, wraplength=600, style="Card.TLabel").grid(row=1, column=1, sticky="w", pady=(8,0))
+
         # Console + progression
         bottom = ttk.Frame(self, style="Card.TFrame", padding=12)
         bottom.pack(fill=tk.BOTH, expand=True, pady=(10,0))
@@ -1653,6 +1663,8 @@ class ContexteEcoTab(ttk.Frame):
         if not self.ze_shp_var.get().strip():
             messagebox.showerror("Erreur", "Sélectionner la Zone d'étude.")
             return
+        self.wiki_climat_var.set("")
+        self.wiki_occupation_var.set("")
         self.wiki_button.config(state="disabled")
         t = threading.Thread(target=self._run_wiki)
         t.daemon = True
@@ -1676,17 +1688,20 @@ class ContexteEcoTab(ttk.Frame):
             else:
                 print(f"[Wiki] Page Wikipédia : {data['url']}", file=self.stdout_redirect)
                 print("[Wiki] CLIMAT :", file=self.stdout_redirect)
-                if data['climat_p1'] != 'Non trouvé':
-                    print(data['climat_p1'], file=self.stdout_redirect)
-                if data['climat_p2'] != 'Non trouvé':
-                    print(data['climat_p2'], file=self.stdout_redirect)
+                if data['climat'] != 'Non trouvé':
+                    print(data['climat'], file=self.stdout_redirect)
                 print("[Wiki] OCCUPATION DES SOLS :", file=self.stdout_redirect)
-                if data['occupation_p1'] != 'Non trouvé':
-                    print(data['occupation_p1'], file=self.stdout_redirect)
+                if data['occupation'] != 'Non trouvé':
+                    print(data['occupation'], file=self.stdout_redirect)
+                self.after(0, lambda d=data: self._update_wiki_section(d))
         except Exception as e:
             print(f"[Wiki] Erreur : {e}", file=self.stdout_redirect)
         finally:
             self.after(0, lambda: self.wiki_button.config(state="normal"))
+
+    def _update_wiki_section(self, data: dict[str, str]) -> None:
+        self.wiki_climat_var.set(data.get("climat", ""))
+        self.wiki_occupation_var.set(data.get("occupation", ""))
 
     def _detect_commune(self, lat: float, lon: float) -> Tuple[str, str]:
         try:

--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -61,33 +61,25 @@ def _find_section_heading(soup: BeautifulSoup, heading_text: str):
 
 def _scrape_sections(driver: webdriver.Chrome) -> Dict[str, str]:
     out = {
-        "climat_p1": "Non trouvé",
-        "climat_p2": "Non trouvé",
-        "occupation_p1": "Non trouvé",
+        "climat": "Non trouvé",
+        "occupation": "Non trouvé",
     }
     soup = BeautifulSoup(driver.page_source, "html.parser")
 
     h = _find_section_heading(soup, "Climat")
     if h:
-        start = None
         for p in h.find_all_next("p"):
             t = p.get_text(strip=True)
-            if t.startswith("En 2010, le climat de la commune est de type") or "climat de la commune est de type" in t:
-                start = p
+            if t.startswith("Pour la période 1971-2000"):
+                out["climat"] = t
                 break
-        if start:
-            fol = start.find_next_siblings("p", limit=2)
-            if len(fol) >= 1:
-                out["climat_p1"] = fol[0].get_text(strip=True)
-            if len(fol) >= 2:
-                out["climat_p2"] = fol[1].get_text(strip=True)
 
     h = _find_section_heading(soup, "Occupation des sols")
     if h:
         for p in h.find_all_next("p"):
             t = p.get_text(strip=True)
             if t.startswith("L'occupation des sols de la commune, telle qu'elle") or "L'occupation des sols de la commune, telle qu'elle ressort" in t:
-                out["occupation_p1"] = t
+                out["occupation"] = t
                 break
     return out
 
@@ -116,7 +108,10 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     except TimeoutException:
         pass
 
-    box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
+    # attente réduite pour saisir la commune
+    box = WebDriverWait(driver, 0.5).until(
+        EC.element_to_be_clickable((By.ID, "searchInput"))
+    )
     box.clear()
     box.send_keys(query)
     box.send_keys(Keys.ENTER)


### PR DESCRIPTION
## Résumé
- Récupération des paragraphes climat et occupation des sols depuis Wikipédia.
- Réduction de l'attente pour saisir la commune dans la recherche Wikipédia.
- Affichage de ces informations dans un petit tableau dédié dans l'onglet Contexte éco.

## Tests
- `python -m py_compile modules/wikipedia_scraper.py modules/main_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68aeb92c6648832cb52e87653bd7bb91