### PR TITLE
Ajout d'une section Wikipedia pour climat et occupation du sol

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -62,25 +62,17 @@ def _find_section_heading(soup: BeautifulSoup, heading_text: str):
 def _scrape_sections(driver: webdriver.Chrome) -> Dict[str, str]:
     out = {
         "climat_p1": "Non trouvé",
-        "climat_p2": "Non trouvé",
         "occupation_p1": "Non trouvé",
     }
     soup = BeautifulSoup(driver.page_source, "html.parser")
 
     h = _find_section_heading(soup, "Climat")
     if h:
-        start = None
         for p in h.find_all_next("p"):
             t = p.get_text(strip=True)
-            if t.startswith("En 2010, le climat de la commune est de type") or "climat de la commune est de type" in t:
-                start = p
+            if t.startswith("Pour la période 1971-2000"):
+                out["climat_p1"] = t
                 break
-        if start:
-            fol = start.find_next_siblings("p", limit=2)
-            if len(fol) >= 1:
-                out["climat_p1"] = fol[0].get_text(strip=True)
-            if len(fol) >= 2:
-                out["climat_p2"] = fol[1].get_text(strip=True)
 
     h = _find_section_heading(soup, "Occupation des sols")
     if h:
@@ -116,7 +108,9 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     except TimeoutException:
         pass
 
-    box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
+    box = WebDriverWait(driver, 0.5).until(
+        EC.element_to_be_clickable((By.ID, "searchInput"))
+    )
     box.clear()
     box.send_keys(query)
     box.send_keys(Keys.ENTER)


### PR DESCRIPTION
## Résumé
- Récupération plus ciblée des paragraphes *Climat* et *Occupation des sols* sur Wikipédia
- Affichage de ces informations dans un nouveau tableau de l'onglet Contexte éco
- Recherche Wikipédia accélérée avec un délai réduit pour la saisie

## Tests
- `python -m py_compile modules/wikipedia_scraper.py modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeb92ad4b8832c866fc761186f474b