### PR TITLE
Ajout d'une section Wikipédia avec informations climat et occupation

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1490,6 +1490,8 @@ class ContexteEcoTab(ttk.Frame):
         self.buffer_var    = tk.DoubleVar(value=float(self.prefs.get("ID_TAMPON_KM", 5.0)))
         self.out_dir_var   = tk.StringVar(value=self.prefs.get("OUT_DIR", OUT_IMG))
         self.export_type_var = tk.StringVar(value=self.prefs.get("EXPORT_TYPE", "BOTH"))
+        self.climat_var = tk.StringVar(value="")
+        self.occupation_var = tk.StringVar(value="")
 
         self.project_vars: dict[str, tk.IntVar] = {}
         self.all_projects: List[str] = []
@@ -1577,8 +1579,17 @@ class ContexteEcoTab(ttk.Frame):
         ttk.Spinbox(idf, from_=0.0, to=50.0, increment=0.5, textvariable=self.buffer_var, width=6, justify="right").grid(row=0, column=1, sticky="w", padx=(8,0))
         self.id_button = ttk.Button(idf, text="Lancer l’ID Contexte éco", style="Accent.TButton", command=self.start_id_thread)
         self.id_button.grid(row=0, column=2, sticky="w", padx=(12,0))
-        self.wiki_button = ttk.Button(idf, text="Wikipedia", style="Accent.TButton", command=self.start_wiki_thread)
-        self.wiki_button.grid(row=0, column=3, sticky="w", padx=(12,0))
+
+        # Section Wikipédia
+        wikif = ttk.Frame(self, style="Card.TFrame", padding=12)
+        wikif.pack(fill=tk.X, pady=(10,0))
+        self.wiki_button = ttk.Button(wikif, text="Wikipedia", style="Accent.TButton", command=self.start_wiki_thread)
+        self.wiki_button.grid(row=0, column=0, sticky="w")
+        ttk.Label(wikif, text="Climat", style="Card.TLabel").grid(row=1, column=0, sticky="nw", pady=(8,0))
+        ttk.Label(wikif, text="Corine Land Cover", style="Card.TLabel").grid(row=2, column=0, sticky="nw")
+        ttk.Label(wikif, textvariable=self.climat_var, style="Card.TLabel", wraplength=400).grid(row=1, column=1, sticky="w", padx=(8,0), pady=(8,0))
+        ttk.Label(wikif, textvariable=self.occupation_var, style="Card.TLabel", wraplength=400).grid(row=2, column=1, sticky="w", padx=(8,0))
+        wikif.columnconfigure(1, weight=1)
 
         # Console + progression
         bottom = ttk.Frame(self, style="Card.TFrame", padding=12)
@@ -1673,16 +1684,16 @@ class ContexteEcoTab(ttk.Frame):
             data, self.wiki_driver = fetch_wikipedia_info(query)
             if "error" in data:
                 print(f"[Wiki] {data['error']}", file=self.stdout_redirect)
+                self.after(0, lambda: (self.climat_var.set("Non trouvé"), self.occupation_var.set("Non trouvé")))
             else:
                 print(f"[Wiki] Page Wikipédia : {data['url']}", file=self.stdout_redirect)
+                self.after(0, lambda: (self.climat_var.set(data['climat']), self.occupation_var.set(data['occupation'])))
                 print("[Wiki] CLIMAT :", file=self.stdout_redirect)
-                if data['climat_p1'] != 'Non trouvé':
-                    print(data['climat_p1'], file=self.stdout_redirect)
-                if data['climat_p2'] != 'Non trouvé':
-                    print(data['climat_p2'], file=self.stdout_redirect)
+                if data['climat'] != 'Non trouvé':
+                    print(data['climat'], file=self.stdout_redirect)
                 print("[Wiki] OCCUPATION DES SOLS :", file=self.stdout_redirect)
-                if data['occupation_p1'] != 'Non trouvé':
-                    print(data['occupation_p1'], file=self.stdout_redirect)
+                if data['occupation'] != 'Non trouvé':
+                    print(data['occupation'], file=self.stdout_redirect)
         except Exception as e:
             print(f"[Wiki] Erreur : {e}", file=self.stdout_redirect)
         finally:

--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -61,33 +61,25 @@ def _find_section_heading(soup: BeautifulSoup, heading_text: str):
 
 def _scrape_sections(driver: webdriver.Chrome) -> Dict[str, str]:
     out = {
-        "climat_p1": "Non trouvé",
-        "climat_p2": "Non trouvé",
-        "occupation_p1": "Non trouvé",
+        "climat": "Non trouvé",
+        "occupation": "Non trouvé",
     }
     soup = BeautifulSoup(driver.page_source, "html.parser")
 
     h = _find_section_heading(soup, "Climat")
     if h:
-        start = None
         for p in h.find_all_next("p"):
             t = p.get_text(strip=True)
-            if t.startswith("En 2010, le climat de la commune est de type") or "climat de la commune est de type" in t:
-                start = p
+            if t.startswith("Pour la période 1971-2000, la température annuelle"):
+                out["climat"] = t
                 break
-        if start:
-            fol = start.find_next_siblings("p", limit=2)
-            if len(fol) >= 1:
-                out["climat_p1"] = fol[0].get_text(strip=True)
-            if len(fol) >= 2:
-                out["climat_p2"] = fol[1].get_text(strip=True)
 
     h = _find_section_heading(soup, "Occupation des sols")
     if h:
         for p in h.find_all_next("p"):
             t = p.get_text(strip=True)
             if t.startswith("L'occupation des sols de la commune, telle qu'elle") or "L'occupation des sols de la commune, telle qu'elle ressort" in t:
-                out["occupation_p1"] = t
+                out["occupation"] = t
                 break
     return out
 
@@ -116,7 +108,7 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     except TimeoutException:
         pass
 
-    box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
+    box = WebDriverWait(driver, 0.5).until(EC.element_to_be_clickable((By.ID, "searchInput")))
     box.clear()
     box.send_keys(query)
     box.send_keys(Keys.ENTER)


### PR DESCRIPTION
## Résumé
- extraction ciblée des paragraphes "Climat" et "Corine Land Cover" depuis Wikipédia
- affichage des extraits dans un tableau dédié de l'onglet Contexte éco
- réduction du délai d'attente à 0,5 s pour la recherche sur Wikipédia

## Tests
- `python -m py_compile modules/wikipedia_scraper.py modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeb9294618832c840653fda1c2974a