### PR TITLE
Ajout d'un résumé Wikipédia pour le contexte éco

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1490,6 +1490,8 @@ class ContexteEcoTab(ttk.Frame):
         self.buffer_var    = tk.DoubleVar(value=float(self.prefs.get("ID_TAMPON_KM", 5.0)))
         self.out_dir_var   = tk.StringVar(value=self.prefs.get("OUT_DIR", OUT_IMG))
         self.export_type_var = tk.StringVar(value=self.prefs.get("EXPORT_TYPE", "BOTH"))
+        self.wiki_climat_var = tk.StringVar()
+        self.wiki_occupation_var = tk.StringVar()
 
         self.project_vars: dict[str, tk.IntVar] = {}
         self.all_projects: List[str] = []
@@ -1579,6 +1581,15 @@ class ContexteEcoTab(ttk.Frame):
         self.id_button.grid(row=0, column=2, sticky="w", padx=(12,0))
         self.wiki_button = ttk.Button(idf, text="Wikipedia", style="Accent.TButton", command=self.start_wiki_thread)
         self.wiki_button.grid(row=0, column=3, sticky="w", padx=(12,0))
+
+        wiki = ttk.Frame(self, style="Card.TFrame", padding=12)
+        wiki.pack(fill=tk.X, pady=(10,0))
+        ttk.Label(wiki, text="Wikipedia", style="Card.TLabel").grid(row=0, column=0, columnspan=2, sticky="w")
+        ttk.Label(wiki, text="Climat", style="Card.TLabel").grid(row=1, column=0, sticky="nw")
+        ttk.Label(wiki, textvariable=self.wiki_climat_var, style="Card.TLabel", wraplength=500, justify="left").grid(row=1, column=1, sticky="w")
+        ttk.Label(wiki, text="Corine Land Cover", style="Card.TLabel").grid(row=2, column=0, sticky="nw", pady=(6,0))
+        ttk.Label(wiki, textvariable=self.wiki_occupation_var, style="Card.TLabel", wraplength=500, justify="left").grid(row=2, column=1, sticky="w", pady=(6,0))
+        wiki.columnconfigure(1, weight=1)
 
         # Console + progression
         bottom = ttk.Frame(self, style="Card.TFrame", padding=12)
@@ -1673,16 +1684,18 @@ class ContexteEcoTab(ttk.Frame):
             data, self.wiki_driver = fetch_wikipedia_info(query)
             if "error" in data:
                 print(f"[Wiki] {data['error']}", file=self.stdout_redirect)
+                self.after(0, lambda: self.wiki_climat_var.set("Non trouvé"))
+                self.after(0, lambda: self.wiki_occupation_var.set("Non trouvé"))
             else:
                 print(f"[Wiki] Page Wikipédia : {data['url']}", file=self.stdout_redirect)
-                print("[Wiki] CLIMAT :", file=self.stdout_redirect)
-                if data['climat_p1'] != 'Non trouvé':
-                    print(data['climat_p1'], file=self.stdout_redirect)
-                if data['climat_p2'] != 'Non trouvé':
-                    print(data['climat_p2'], file=self.stdout_redirect)
-                print("[Wiki] OCCUPATION DES SOLS :", file=self.stdout_redirect)
-                if data['occupation_p1'] != 'Non trouvé':
-                    print(data['occupation_p1'], file=self.stdout_redirect)
+                if data['climat'] != 'Non trouvé':
+                    print("[Wiki] CLIMAT :", file=self.stdout_redirect)
+                    print(data['climat'], file=self.stdout_redirect)
+                if data['occupation'] != 'Non trouvé':
+                    print("[Wiki] OCCUPATION DES SOLS :", file=self.stdout_redirect)
+                    print(data['occupation'], file=self.stdout_redirect)
+                self.after(0, lambda: self.wiki_climat_var.set(data['climat']))
+                self.after(0, lambda: self.wiki_occupation_var.set(data['occupation']))
         except Exception as e:
             print(f"[Wiki] Erreur : {e}", file=self.stdout_redirect)
         finally:


### PR DESCRIPTION
## Résumé
- Récupère le paragraphe climat (1971-2000) et l'occupation des sols sur Wikipédia
- Affiche ces informations dans une nouvelle section de l'onglet Contexte éco
- Réduction du délai avant la saisie de la commune dans la barre de recherche

## Tests
- `python -m py_compile modules/wikipedia_scraper.py modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeb92849bc832c90e85eff5fbb86a0