### PR TITLE
Sélection de la première suggestion Wikipédia

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -17,6 +17,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
+import time
 
 # Départements courants (ajoutez si besoin)
 DEP: Dict[str, str] = {
@@ -119,6 +120,9 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
     box.clear()
     box.send_keys(query)
+    # Sélectionne la première suggestion pour garantir l'ouverture de la bonne page
+    time.sleep(1)
+    box.send_keys(Keys.ARROW_DOWN)
     box.send_keys(Keys.ENTER)
 
     try:


### PR DESCRIPTION
## Résumé
- choisit automatiquement la première suggestion dans la recherche Wikipédia
- ajoute un court délai pour laisser apparaître la liste déroulante

## Tests
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aed8306dc4832ca1a8c5a0f66b0912