### PR TITLE
Corrige la navigation vers les pages Wikipédia des communes

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -97,7 +97,7 @@ def _normalize_query(s: str) -> str:
     m = re.match(r"^(.*?)[\s,;_-]*\(?(\d{2})\)?$", s)
     if m and m.group(2) in DEP:
         base = m.group(1).strip()
-        return f"{base} ({DEP[m.group(2)]})"
+        return f"{base} ({m.group(2)})"
     return s
 
 
@@ -119,7 +119,14 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
     box.clear()
     box.send_keys(query)
-    box.send_keys(Keys.ENTER)
+    try:
+        wait.until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, ".suggestions-results"))
+        )
+        box.send_keys(Keys.ARROW_DOWN)
+        box.send_keys(Keys.ENTER)
+    except TimeoutException:
+        box.send_keys(Keys.ENTER)
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))
@@ -140,7 +147,7 @@ def fetch_wikipedia_info(commune_query: str) -> Tuple[Dict[str, str], webdriver.
     afin que l'utilisateur décide quand fermer la fenêtre du navigateur.
 
     ``commune_query`` peut être de la forme ``"Vizille 38"`` ou
-    ``"Vizille (Isère)``.
+    ``"Vizille (38)``.
     """
 
     query = _normalize_query(commune_query)


### PR DESCRIPTION
## Résumé
- Conserve le numéro du département dans la requête vers Wikipédia
- Sélectionne automatiquement la première suggestion lors de la recherche

## Tests
- `python -m py_compile modules/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68aed82f1730832cb79c284003d197d7