### PR TITLE
Améliore la navigation vers les pages Wikipédia

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -17,6 +17,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
+import time
 
 # Départements courants (ajoutez si besoin)
 DEP: Dict[str, str] = {
@@ -118,13 +119,14 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
 
     box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
     box.clear()
+    time.sleep(0.5)
     box.send_keys(query)
     try:
         wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, ".suggestions-results")))
-        box.send_keys(Keys.ARROW_DOWN)
-        box.send_keys(Keys.ENTER)
     except TimeoutException:
-        box.send_keys(Keys.ENTER)
+        pass
+    box.send_keys(Keys.ARROW_DOWN)
+    box.send_keys(Keys.ENTER)
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))


### PR DESCRIPTION
## Résumé
- Ajout d'une courte pause avant la saisie pour accélérer l'ouverture de Wikipédia
- Sélection automatique de la première suggestion puis validation avec la touche Entrée

## Tests
- `python -m py_compile modules/wikipedia_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68aee94205f4832cb77961e7c8664c95