### PR TITLE
Utilisation des touches clavier pour sélectionner une suggestion Wikipédia

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -116,16 +116,13 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     except TimeoutException:
         pass
 
-    box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
+    box = WebDriverWait(driver, 0.5).until(
+        EC.element_to_be_clickable((By.ID, "searchInput"))
+    )
     box.clear()
     box.send_keys(query)
-    try:
-        first = WebDriverWait(driver, 1).until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, ".suggestions-results a"))
-        )
-        first.click()
-    except TimeoutException:
-        box.send_keys(Keys.ENTER)
+    box.send_keys(Keys.ARROW_DOWN)
+    box.send_keys(Keys.ENTER)
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))


### PR DESCRIPTION
## Résumé
- Utilisation d'un WebDriverWait de 0,5 s pour attendre que la barre de recherche soit prête
- Saisie de la commune puis sélection de la première suggestion via les touches flèche bas et Entrée

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef0873ac4832caecf17a38345d44c