### PR TITLE
Sélection automatique de la première suggestion Wikipédia

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -116,16 +116,15 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     except TimeoutException:
         pass
 
-    box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
+    # Le champ de recherche est attendu au maximum 0,5 s puis on
+    # reproduit les actions clavier : saisie, flèche bas et validation.
+    box = WebDriverWait(driver, 0.5).until(
+        EC.element_to_be_clickable((By.ID, "searchInput"))
+    )
     box.clear()
     box.send_keys(query)
-    try:
-        first = WebDriverWait(driver, 1).until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, ".suggestions-results a"))
-        )
-        first.click()
-    except TimeoutException:
-        box.send_keys(Keys.ENTER)
+    box.send_keys(Keys.ARROW_DOWN)
+    box.send_keys(Keys.ENTER)
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))


### PR DESCRIPTION
## Résumé
- Saisie de la recherche avec un délai maximal de 0,5 seconde
- Navigation dans la liste par flèche bas puis ouverture de la page via Entrée

## Test
- `python -m py_compile modules/wikipedia_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68aef0881fdc832cb7a4fbc1efa78a53