### PR TITLE
Sélection automatique de la première suggestion Wikipédia

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -116,16 +116,14 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     except TimeoutException:
         pass
 
-    box = wait.until(EC.element_to_be_clickable((By.ID, "searchInput")))
+    box = WebDriverWait(driver, 0.5).until(
+        EC.element_to_be_clickable((By.ID, "searchInput"))
+    )
     box.clear()
     box.send_keys(query)
-    try:
-        first = WebDriverWait(driver, 1).until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, ".suggestions-results a"))
-        )
-        first.click()
-    except TimeoutException:
-        box.send_keys(Keys.ENTER)
+    # Descendre dans les suggestions et valider l'entrée
+    box.send_keys(Keys.ARROW_DOWN)
+    box.send_keys(Keys.ENTER)
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))


### PR DESCRIPTION
## Résumé
- Attente (0,5 s max) de la barre de recherche de Wikipédia
- Saisie de la commune puis navigation dans la liste de suggestions avec Flèche bas et validation avec Entrée

## Tests
- `python -m py_compile modules/wikipedia_scraper.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aef09391e0832cafd41ea73ab166ce