### PR TITLE
Sélection automatique de la première suggestion Wikipédia

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -120,10 +120,14 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     box.clear()
     box.send_keys(query)
     try:
-        first = WebDriverWait(driver, 1).until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, ".suggestions-results a"))
+        WebDriverWait(driver, 0.5).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, ".suggestions-results"))
         )
-        first.click()
+        suggestions = driver.find_elements(By.CSS_SELECTOR, ".suggestions-result a")
+        if suggestions:
+            suggestions[0].click()
+        else:
+            box.send_keys(Keys.ENTER)
     except TimeoutException:
         box.send_keys(Keys.ENTER)
 


### PR DESCRIPTION
## Résumé
- le robot attend l'apparition des suggestions de recherche sur Wikipédia
- il clique sur la première proposition au lieu d'envoyer directement "Entrée"

## Tests
- `python -m py_compile modules/wikipedia_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68aef098f5bc832c8fff69ab81118109