### PR TITLE
Clique automatisée sur la première suggestion Wikipédia

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -14,6 +14,7 @@ from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
@@ -121,8 +122,13 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     )
     box.clear()
     box.send_keys(query)
-    box.send_keys(Keys.ARROW_DOWN)
-    box.send_keys(Keys.ENTER)
+    try:
+        suggestion = WebDriverWait(driver, 0.5).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, ".suggestions-result"))
+        )
+        ActionChains(driver).move_to_element(suggestion).click().perform()
+    except TimeoutException:
+        box.send_keys(Keys.ENTER)
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))


### PR DESCRIPTION
## Résumé
- Simuler un clic souris sur la première suggestion de recherche Wikipedia.
- Revenir sur la page de la commune sans utiliser uniquement le clavier.

## Tests
- `python -m py_compile modules/wikipedia_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68aef31f9f5c832c906692ca283bce32