### PR TITLE
Cliquer sur la première suggestion Wikipédia pour les recherches

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -121,8 +121,17 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     )
     box.clear()
     box.send_keys(query)
-    box.send_keys(Keys.ARROW_DOWN)
-    box.send_keys(Keys.ENTER)
+    try:
+        WebDriverWait(driver, 0.5).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, ".suggestions-results"))
+        )
+        suggestions = driver.find_elements(By.CSS_SELECTOR, ".suggestions-result a")
+        if suggestions:
+            suggestions[0].click()
+        else:
+            box.send_keys(Keys.ENTER)
+    except TimeoutException:
+        box.send_keys(Keys.ENTER)
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))


### PR DESCRIPTION
## Résumé
- Lorsqu'on saisit une commune, le script attend désormais l'apparition des suggestions Wikipédia et clique automatiquement sur la première proposition.
- Si aucune suggestion n'est trouvée en 0,5 seconde, la recherche classique est lancée.

## Tests
- `python -m py_compile modules/wikipedia_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68aef31bad04832ca670722b23eb18ab