### PR TITLE
Clique automatique sur la première suggestion Wikipédia

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -14,6 +14,7 @@ from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
@@ -121,8 +122,13 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     )
     box.clear()
     box.send_keys(query)
-    box.send_keys(Keys.ARROW_DOWN)
-    box.send_keys(Keys.ENTER)
+    try:
+        first = WebDriverWait(driver, 0.5).until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, ".suggestions-result"))
+        )
+        ActionChains(driver).move_to_element(first).click().perform()
+    except TimeoutException:
+        box.send_keys(Keys.ENTER)
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))


### PR DESCRIPTION
## Résumé
- Le script attend brièvement l'affichage de la liste de suggestions.
- Il simule un clic sur la première proposition afin d'ouvrir la page correspondante.

## Tests
- `python -m py_compile modules/wikipedia_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_68aef320c37c832cae90081012ce0f9e