### PR TITLE
Correction de la navigation Wikipédia via Selenium

### DIFF
--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -13,7 +13,6 @@ from typing import Dict, Tuple
 from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
@@ -102,7 +101,9 @@ def _normalize_query(s: str) -> str:
 
 
 def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> bool:
-    driver.get("https://fr.wikipedia.org/")
+    driver.get(
+        "https://fr.wikipedia.org/w/index.php?search=&title=Sp%C3%A9cial%3ARecherche&profile=advanced&fulltext=1&ns0=1"
+    )
     try:
         btn = WebDriverWait(driver, 0.5).until(
             EC.element_to_be_clickable(
@@ -116,21 +117,27 @@ def _open_article(driver: webdriver.Chrome, query: str, wait: WebDriverWait) -> 
     except TimeoutException:
         pass
 
-    box = WebDriverWait(driver, 0.5).until(
-        EC.element_to_be_clickable((By.ID, "searchInput"))
-    )
+    box = wait.until(EC.element_to_be_clickable((By.NAME, "search")))
     box.clear()
     box.send_keys(query)
-    box.send_keys(Keys.ARROW_DOWN)
-    box.send_keys(Keys.ENTER)
+
+    search_btn = wait.until(
+        EC.element_to_be_clickable(
+            (
+                By.XPATH,
+                "//span[@class='oo-ui-labelElement-label' and text()='Rechercher']/ancestor::button",
+            )
+        )
+    )
+    search_btn.click()
 
     try:
         wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))
-        if "Spécial:Recherche" in driver.current_url or "Special:Search" in driver.current_url:
-            link = wait.until(
+        if "Sp%C3%A9cial:Recherche" in driver.current_url or "Special:Search" in driver.current_url:
+            first = wait.until(
                 EC.element_to_be_clickable((By.CSS_SELECTOR, "div.mw-search-result-heading a"))
             )
-            link.click()
+            first.click()
             wait.until(EC.presence_of_element_located((By.ID, "firstHeading")))
         return True
     except TimeoutException:


### PR DESCRIPTION
## Résumé
- utilisation de la page de recherche avancée de Wikipédia pour trouver une commune
- automatisation du clic sur le premier résultat de recherche

## Tests
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef6a97050832c942f76fefc3fc934