### PR TITLE
Ajout d'un troisième onglet FloreApp sans activer la carte des sols

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1724,12 +1724,45 @@ class ContexteEcoTab(ttk.Frame):
                             (By.CSS_SELECTOR, "a.leaflet-control-layers-toggle")
                         )
                     ).click()
-                    # 6) Activer la couche "Carte flore"
+                    # 6) Activer la couche "Carte des sols"
                     wait.until(
                         EC.element_to_be_clickable(
-                            (By.XPATH, "//*[contains(text(),'Carte flore')]")
+                            (By.XPATH, "//*[contains(text(),'Carte des sols')]")
                         )
                     ).click()
+                    # 7) Ouvrir un troisième onglet sans la couche "Carte des sols"
+                    self.wiki_driver.execute_script(
+                        "window.open('https://floreapp.netlify.app/biblio-patri.html','_blank');"
+                    )
+                    self.wiki_driver.switch_to.window(self.wiki_driver.window_handles[-1])
+                    addr = wait.until(
+                        EC.element_to_be_clickable((By.ID, "address-input"))
+                    )
+                    addr.click()
+                    addr.clear()
+                    addr.send_keys(coords_dms)
+                    wait.until(
+                        EC.element_to_be_clickable((By.ID, "search-address-btn"))
+                    ).click()
+                    wait.until(
+                        EC.element_to_be_clickable(
+                            (By.CSS_SELECTOR, "a.leaflet-control-layers-toggle")
+                        )
+                    ).click()
+                    # 8) Ne pas activer "Carte des sols" (la laisser décochée)
+                    try:
+                        layer_cb = wait.until(
+                            EC.element_to_be_clickable(
+                                (
+                                    By.XPATH,
+                                    "//label[contains(.,'Carte des sols')]/preceding-sibling::input",
+                                )
+                            )
+                        )
+                        if layer_cb.is_selected():
+                            layer_cb.click()
+                    except Exception:
+                        pass
                 except Exception as fe:
                     print(
                         f"[Wiki] Étapes FloreApp échouées : {fe}",


### PR DESCRIPTION
## Résumé
- Sélection de la couche "Carte des sols" pour l'onglet FloreApp existant.
- Ouverture d'un troisième onglet FloreApp répétant la recherche mais en laissant "Carte des sols" désactivée.
- Le navigateur reste ouvert pour permettre la consultation des trois onglets.

## Tests
- `python -m py_compile modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aefc491ed4832cb0e6c191907339aa