### PR TITLE
Fix: ajout des dossiers QGIS pour l’export

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -314,12 +314,19 @@ def worker_run(args: Tuple[List[str], dict]) -> Tuple[int, int]:
         else ("minimal" if os.path.isfile(os.path.join(platform_dir, "qminimal.dll")) else "offscreen")
     os.environ["QT_QPA_PLATFORM"] = qpa
 
-    os.environ["PATH"] = os.pathsep.join([
+    dll_dirs = [
         os.path.join(qt_base, "bin"),
         os.path.join(cfg["QGIS_APP"], "bin"),
         os.path.join(cfg["QGIS_ROOT"], "bin"),
-        os.environ.get("PATH", ""),
-    ])
+    ]
+    os.environ["PATH"] = os.pathsep.join(dll_dirs + [os.environ.get("PATH", "")])
+
+    if hasattr(os, "add_dll_directory"):
+        for d in dll_dirs:
+            try:
+                os.add_dll_directory(d)
+            except (FileNotFoundError, OSError):
+                pass
 
     sys.path.insert(0, os.path.join(cfg["QGIS_APP"], "python"))
     sys.path.insert(0, os.path.join(cfg["QGIS_ROOT"], "apps", cfg["PY_VER"], "Lib", "site-packages"))
@@ -793,8 +800,25 @@ class ExportCartesTab(ttk.Frame):
             qt_base = None
             for name in ("Qt6", "Qt5"):
                 base = os.path.join(QGIS_ROOT, "apps", name)
-                if os.path.isdir(base): qt_base = base; break
-            if not qt_base: raise RuntimeError("Répertoire Qt introuvable")
+                if os.path.isdir(base):
+                    qt_base = base
+                    break
+            if not qt_base:
+                raise RuntimeError("Répertoire Qt introuvable")
+
+            dll_dirs = [
+                os.path.join(qt_base, "bin"),
+                os.path.join(QGIS_APP, "bin"),
+                os.path.join(QGIS_ROOT, "bin"),
+            ]
+            os.environ["PATH"] = os.pathsep.join(dll_dirs + [os.environ.get("PATH", "")])
+            if hasattr(os, "add_dll_directory"):
+                for d in dll_dirs:
+                    try:
+                        os.add_dll_directory(d)
+                    except (FileNotFoundError, OSError):
+                        pass
+
             sys.path.insert(0, os.path.join(QGIS_APP, "python"))
             sys.path.insert(0, os.path.join(QGIS_ROOT, "apps", PY_VER, "Lib", "site-packages"))
             from qgis.core import QgsApplication  # noqa: F401


### PR DESCRIPTION
## Résumé
- gère explicitement les dossiers contenant les DLL de QGIS
- améliore le test de disponibilité de QGIS

## Test
- `python -m py_compile modules/main_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68af5d86ced8832c8e78433510798cbc