### PR TITLE
Gestion manquante de QGIS pour l'export des cartes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ L'application s'ouvrira avec plusieurs onglets proposant les fonctionnalités pr
 
 Les modules standard de Python suffisent pour lancer l'application de base. Certaines fonctionnalités peuvent requérir des bibliothèques supplémentaires, installables via `pip`.
 
+L'export des cartes de l'onglet « Contexte éco » nécessite une installation de QGIS. Le chemin d'accès est défini dans `modules/main_app.py` via la variable `QGIS_ROOT`; adaptez-le à votre installation.
+

--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -839,6 +839,19 @@ class ExportCartesTab(ttk.Frame):
             start = datetime.datetime.now()
             os.makedirs(OUT_IMG, exist_ok=True)
 
+            if not os.path.isdir(QGIS_ROOT):
+                log_with_time(f"Dossier QGIS introuvable: {QGIS_ROOT}")
+                self.after(0, lambda: messagebox.showerror(
+                    "Erreur", f"Dossier QGIS introuvable:\n{QGIS_ROOT}"))
+                return
+            try:
+                from qgis import core as _  # type: ignore
+            except Exception as e:
+                log_with_time(f"Import QGIS impossible: {e}")
+                self.after(0, lambda: messagebox.showerror(
+                    "Erreur", "Impossible de charger QGIS. Vérifiez son installation."))
+                return
+
             log_with_time(f"{len(projets)} projets (attendu = calcul en cours)")
             log_with_time(f"Workers={self.workers_var.get()}, DPI={self.dpi_var.get()}, marge={self.margin_var.get():.2f}, overwrite={self.overwrite_var.get()}")
 


### PR DESCRIPTION
## Résumé
- Vérifie la présence de QGIS avant de lancer l'export et affiche un message d'erreur explicite si nécessaire
- Documente la nécessité d'installer QGIS et d'ajuster `QGIS_ROOT`

## Test
- `python -m py_compile modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68af5d882878832c8b30ddf201517432