### PR TITLE
Gestion explicite des DLL QGIS et test d'environnement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,15 @@ L'application s'ouvrira avec plusieurs onglets proposant les fonctionnalités pr
 
 Les modules standard de Python suffisent pour lancer l'application de base. Certaines fonctionnalités peuvent requérir des bibliothèques supplémentaires, installables via `pip`.
 
+## Export cartes sous Windows
+
+Avec Python 3.12 sur Windows, l'export cartographique utilise le module QGIS. Depuis Python 3.8, le chargeur ne cherche plus automatiquement les DLL de QGIS et Qt dans les processus enfants. Pour assurer un import correct, l'application ajoute explicitement les dossiers de DLL via `os.add_dll_directory` et lit les variables d'environnement suivantes si elles sont définies :
+
+- `QGIS_ROOT`
+- `QGIS_APP`
+- `QGIS_PREFIX_PATH`
+- `QT_DIR`
+- `QT_QPA_PLATFORM_PLUGIN_PATH`
+
+Si l'import QGIS échoue, un test de fumée (accessible depuis l'onglet Export cartes) affiche un message d'erreur lisible. Dans certains cas, l'application se replie automatiquement sur un seul worker pour contourner des problèmes de chargement de DLL.
+

--- a/modules/qgis_env.py
+++ b/modules/qgis_env.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+import os
+import platform
+import traceback
+
+
+def _dedup_dirs(dirs):
+    seen = set()
+    out = []
+    for d in dirs:
+        if not d:
+            continue
+        d = os.path.abspath(d)
+        if os.path.isdir(d) and d not in seen:
+            seen.add(d)
+            out.append(d)
+    return out
+
+
+def prepare_qgis_env(cfg: dict | None = None) -> None:
+    """Idempotent. À appeler dans CHAQUE process AVANT 'from qgis.core import ...'."""
+    if platform.system() != "Windows":
+        return
+    cfg = cfg or {}
+
+    # Collecte des candidats DLL
+    candidates = []
+    for key in ("QGIS_ROOT", "QGIS_APP", "QT_DIR"):
+        base = cfg.get(key) or os.environ.get(key, "")
+        if base:
+            candidates += [base, os.path.join(base, "bin")]
+
+    # Ajout des répertoires connus de plugins Qt/QGIS si fournis
+    qt_plugins = cfg.get("QT_QPA_PLATFORM_PLUGIN_PATH") or os.environ.get("QT_QPA_PLATFORM_PLUGIN_PATH", "")
+    if not qt_plugins and (cfg.get("QT_DIR") or os.environ.get("QT_DIR")):
+        qt_base = cfg.get("QT_DIR") or os.environ.get("QT_DIR")
+        qt_plugins = os.path.join(qt_base, "plugins", "platforms")
+
+    dll_dirs = _dedup_dirs(candidates)
+
+    # Déclare les dossiers DLL au loader (Python >=3.8)
+    for d in dll_dirs:
+        try:
+            os.add_dll_directory(d)
+        except Exception:
+            pass
+
+    # Sécurise PATH en plus (utile pour certaines dépendances secondaires)
+    os.environ["PATH"] = os.pathsep.join(dll_dirs + [os.environ.get("PATH", "")])
+
+    # QGIS prefix
+    if cfg.get("QGIS_PREFIX_PATH") or os.environ.get("QGIS_PREFIX_PATH"):
+        os.environ["QGIS_PREFIX_PATH"] = cfg.get("QGIS_PREFIX_PATH") or os.environ["QGIS_PREFIX_PATH"]
+
+    # Qt platform plugins
+    if qt_plugins and os.path.isdir(qt_plugins):
+        os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = qt_plugins
+
+
+def qgis_smoke_test(cfg: dict | None) -> tuple[bool, str]:
+    try:
+        prepare_qgis_env(cfg)
+        from qgis.core import QgsApplication  # noqa: F401
+        return True, "Import QGIS OK"
+    except Exception as e:
+        return False, f"Import QGIS KO: {e}\n{traceback.format_exc()}"


### PR DESCRIPTION
## Résumé
- ajout d'un utilitaire `qgis_env` pour charger les DLL Qt/QGIS et tester l'import
- initialisation explicite de l'environnement QGIS dans les workers
- test de fumée QGIS et repli automatique à un seul worker si nécessaire

## Tests
- `python -m py_compile modules/qgis_env.py modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68af62ddc150832c923f3550eac07fd0