### PR TITLE
Ajout d'un bouton 'Ouput' pour ouvrir le dossier d'export

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1302,6 +1302,7 @@ class ExportCartesTab(ttk.Frame):
         bottom.columnconfigure(0, weight=1)
         bottom.rowconfigure(0, weight=1)
         ttk.Label(bottom, text="Console", style="Subtle.TLabel").grid(row=0, column=0, sticky="w", padx=6, pady=(4,0))
+        ttk.Button(bottom, text="Ouput", command=self._open_output_dir).grid(row=0, column=1, sticky="e", padx=6, pady=(4,0))
         console_frm = ttk.Frame(bottom)
         console_frm.grid(row=1, column=0, sticky="nsew", padx=6, pady=(0,6))
         console_frm.columnconfigure(0, weight=1)


### PR DESCRIPTION
## Résumé
- Ajout d'un bouton **Ouput** au-dessus de la console pour ouvrir rapidement le dossier d'export

## Tests
- `python scripts/smoke_test.py`
- `python -m py_compile modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3139a5508832c88a530f043d404ad