### PR TITLE
feat: identifier commune depuis la zone d'étude

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1109,6 +1109,8 @@ class ExportCartesTab(ttk.Frame):
         self.export_type_var = tk.StringVar(value=self.prefs.get("EXPORT_TYPE", "BOTH"))  # PNG, QGS, BOTH
         # Wiki query manual override
         self.wiki_query_var = tk.StringVar(value=self.prefs.get("WIKI_QUERY", ""))
+        # Resultat de la détection de commune
+        self.commune_var = tk.StringVar(value="")
 
         # Root layout: left controls, right projects, bottom console
         root = ttk.Frame(self, style="Header.TFrame")
@@ -1140,9 +1142,13 @@ class ExportCartesTab(ttk.Frame):
         ae_entry.grid(row=2, column=1, sticky="ew", padx=(6,6))
         ttk.Button(left, text="Parcourir…", command=lambda: self._browse_file(self.ae_shp_var)).grid(row=2, column=2)
 
+        # Commune detection
+        ttk.Button(left, text="Identifier commune", command=self.identify_commune).grid(row=3, column=0, sticky="w", pady=(4,0))
+        ttk.Label(left, textvariable=self.commune_var).grid(row=3, column=1, columnspan=2, sticky="w", padx=(6,0))
+
         # Export options
         opt_frm = ttk.Frame(left)
-        opt_frm.grid(row=3, column=0, columnspan=3, sticky="ew", pady=(8,4))
+        opt_frm.grid(row=4, column=0, columnspan=3, sticky="ew", pady=(8,4))
         for i in range(6):
             opt_frm.columnconfigure(i, weight=1)
 
@@ -1165,9 +1171,9 @@ class ExportCartesTab(ttk.Frame):
         ttk.Radiobutton(types, text="Les deux", value="BOTH", variable=self.export_type_var, style="Card.TRadiobutton").pack(side="left", padx=(8,0))
 
         # Output directory
-        ttk.Label(left, text="Dossier de sortie").grid(row=4, column=0, sticky="w", pady=(4,0))
+        ttk.Label(left, text="Dossier de sortie").grid(row=5, column=0, sticky="w", pady=(4,0))
         out_frm = ttk.Frame(left)
-        out_frm.grid(row=4, column=1, columnspan=2, sticky="ew", padx=(6,0), pady=(4,0))
+        out_frm.grid(row=5, column=1, columnspan=2, sticky="ew", padx=(6,0), pady=(4,0))
         out_frm.columnconfigure(0, weight=1)
         out_entry = ttk.Entry(out_frm, textvariable=self.out_dir_var, width=48, style="Card.TEntry")
         out_entry.grid(row=0, column=0, sticky="ew")
@@ -1181,7 +1187,7 @@ class ExportCartesTab(ttk.Frame):
 
         # Actions: Export, Identification
         act_frm = ttk.Frame(left)
-        act_frm.grid(row=5, column=0, columnspan=3, sticky="ew", pady=(10,4))
+        act_frm.grid(row=6, column=0, columnspan=3, sticky="ew", pady=(10,4))
         act_frm.columnconfigure(0, weight=1)
         act_frm.columnconfigure(1, weight=1)
         self.export_button = ttk.Button(act_frm, text="Exporter cartes", style="Accent.TButton", command=self.start_export_thread)
@@ -1191,13 +1197,13 @@ class ExportCartesTab(ttk.Frame):
 
         # ID buffer
         id_frm = ttk.Frame(left)
-        id_frm.grid(row=6, column=0, columnspan=3, sticky="ew", pady=(4,8))
+        id_frm.grid(row=7, column=0, columnspan=3, sticky="ew", pady=(4,8))
         ttk.Label(id_frm, text="Tampon (km)").pack(side="left")
         ttk.Spinbox(id_frm, from_=0.0, to=20.0, increment=0.5, textvariable=self.buffer_var, width=6).pack(side="left", padx=(6,0))
 
         # Quick tools: RLT, Maps, BV
         tools_frm = ttk.Frame(left)
-        tools_frm.grid(row=7, column=0, columnspan=3, sticky="ew", pady=(2,10))
+        tools_frm.grid(row=8, column=0, columnspan=3, sticky="ew", pady=(2,10))
         self.rlt_button = ttk.Button(tools_frm, text="Remonter le temps (IGN)", command=self.start_rlt_thread)
         self.rlt_button.pack(side="left")
         ttk.Button(tools_frm, text="Google Maps", command=self.open_gmaps).pack(side="left", padx=6)
@@ -1206,7 +1212,7 @@ class ExportCartesTab(ttk.Frame):
 
         # Wikipedia + Veg/Sol scraping controls
         wiki_frm = ttk.LabelFrame(left, text="Scraping Wikipedia / Veg&Sol")
-        wiki_frm.grid(row=8, column=0, columnspan=3, sticky="ew", pady=(8,4))
+        wiki_frm.grid(row=9, column=0, columnspan=3, sticky="ew", pady=(8,4))
         wiki_frm.columnconfigure(0, weight=1)
 
         wiki_sub_frm = ttk.Frame(wiki_frm)
@@ -1582,6 +1588,37 @@ class ExportCartesTab(ttk.Frame):
         except Exception as e:
             messagebox.showerror("Erreur Géospatiale", f"Impossible de calculer le centroïde du shapefile. Erreur: {e}")
             return None
+
+    def identify_commune(self):
+        """Identifie la commune et le département du centroïde de la ZE."""
+        centroid = self._get_centroid_wgs84()
+        if not centroid:
+            return
+        lat, lon = centroid
+        try:
+            url = (
+                f"https://geo.api.gouv.fr/communes?lat={lat}&lon={lon}"
+                "&fields=nom,codeDepartement&format=json"
+            )
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            if not data:
+                raise ValueError("Aucune commune trouvée")
+            info = data[0]
+            commune = info.get("nom", "Inconnue")
+            dep = info.get("codeDepartement", "?")
+            self.commune_var.set(f"{commune} ({dep})")
+            try:
+                self.wiki_query_var.set(commune)
+            except Exception:
+                pass
+            messagebox.showinfo(
+                "Commune",
+                f"Centre de la ZE : {lat:.5f}, {lon:.5f}\nCommune : {commune} ({dep})",
+            )
+        except Exception as e:
+            messagebox.showerror("Erreur", f"Impossible d'identifier la commune : {e}")
 
     def _run_wiki_scrape(self, driver, query: str) -> dict:
         print(f"Lancement du scraping Wikipedia pour: '{query}'")


### PR DESCRIPTION
## Résumé
- Ajout d'un bouton **Identifier commune** sous les champs de shapefile
- Calcul du centroïde de la ZE et récupération de la commune/département via l'API officielle
- Affichage du résultat et pré-remplissage de la recherche Wikipédia

## Tests
- `python -m py_compile modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3133778d8832cb773f10d715dd9f6