### PR TITLE
Le bouton "Remonter le temps" utilise le centroïde du shapefile

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -30,7 +30,7 @@ Onglet « Identification Pl@ntNet » :
 
 Pré-requis Python : qgis (environnement QGIS), selenium, pillow, python-docx,
 
-openpyxl (non utilisé ici), chromedriver dans PATH.
+chromedriver dans PATH.
 
 """
 
@@ -70,7 +70,6 @@ from docx.enum.section import WD_ORIENT
 from docx.enum.table import WD_TABLE_ALIGNMENT
 from docx.oxml.ns import qn
 
-from openpyxl import load_workbook
 from PIL import Image
 
 from selenium import webdriver
@@ -1336,27 +1335,28 @@ class ExportCartesTab(ttk.Frame):
 
     def _open_rlt_links(self):
         try:
-            # --- Utiliser les chemins et paramètres de l'ancienne version ---
-            excel_path = r"C:\Users\utilisateur\Mon Drive\1 - Bota & Travail\+++++++++  BOTA  +++++++++\---------------------- 3) BDD\TOOL Excel.xlsm"
-            output_dir = r"C:\Users\utilisateur\Mon Drive\1 - Bota & Travail\+++++++++  BOTA  +++++++++\---------------------- 3) BDD\PYTHON\2) Contexte éco\OUTPUT\Remonter le temps"
+            centroid = self._get_centroid_wgs84()
+            if not centroid:
+                return
+            lat_dd, lon_dd = centroid
+
+            # Essayer de récupérer le nom de la commune depuis le shapefile
+            commune = ""
+            try:
+                shp_path = self.ze_shp_var.get()
+                gdf = gpd.read_file(shp_path)
+                for col in ["commune", "nom", "NOM_COM", "NOM"]:
+                    if col in gdf.columns:
+                        commune = str(gdf.iloc[0][col])
+                        break
+            except Exception:
+                pass
+
+            output_dir = os.path.join(self.out_dir_var.get() or OUT_IMG, "Remonter le temps")
             word_filename = "Comparaison_temporelle_Paysage.docx"
             os.makedirs(output_dir, exist_ok=True)
 
-            # --- 1. Lecture des données depuis Excel ---
-            print("Lecture des coordonnées depuis le fichier Excel...")
-            tmp_dir = tempfile.mkdtemp(prefix="excel_tmp_")
-            tmp_file = os.path.join(tmp_dir, "copy.xlsm")
-            shutil.copy2(excel_path, tmp_file)
-
-            wb = load_workbook(tmp_file, read_only=True, data_only=True, keep_vba=False)
-            ws = wb["0  PYTHON"]
-            coord_raw = str(ws["H5"].value).strip()
-            commune = str(ws["I5"].value).strip()
-            wb.close()
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-
-            lat_dd, lon_dd = (dms_to_dd(s) for s in re.split(r"\s+|,|\t", coord_raw, maxsplit=1))
-            print(f"Commune: {commune}, Coordonnées: {lat_dd:.6f}, {lon_dd:.6f}")
+            print(f"Coordonnées utilisées : {lat_dd:.6f}, {lon_dd:.6f}")
 
             # --- 2. Capture des images avec Selenium ---
             print("Lancement de la capture d'images...")


### PR DESCRIPTION
## Résumé
- Le bouton *Remonter le temps* calcule désormais les coordonnées à partir du centroïde du shapefile choisi.
- Suppression de la lecture des coordonnées dans un fichier Excel et de la dépendance à `openpyxl`.

## Tests
- `python -m py_compile modules/main_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b3137a8770832cb53c76e1c9c670fd