### PR TITLE
Utiliser le centroïde du shapefile pour Remonter le temps

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -70,7 +70,6 @@ from docx.enum.section import WD_ORIENT
 from docx.enum.table import WD_TABLE_ALIGNMENT
 from docx.oxml.ns import qn
 
-from openpyxl import load_workbook
 from PIL import Image
 
 from selenium import webdriver
@@ -1336,29 +1335,24 @@ class ExportCartesTab(ttk.Frame):
 
     def _open_rlt_links(self):
         try:
-            # --- Utiliser les chemins et paramètres de l'ancienne version ---
-            excel_path = r"C:\Users\utilisateur\Mon Drive\1 - Bota & Travail\+++++++++  BOTA  +++++++++\---------------------- 3) BDD\TOOL Excel.xlsm"
-            output_dir = r"C:\Users\utilisateur\Mon Drive\1 - Bota & Travail\+++++++++  BOTA  +++++++++\---------------------- 3) BDD\PYTHON\2) Contexte éco\OUTPUT\Remonter le temps"
+            # --- Récupération des coordonnées depuis le shapefile ---
+            centroid = self._get_centroid_wgs84()
+            if not centroid:
+                return
+            lat_dd, lon_dd = centroid  # lat, lon
+
+            # Utiliser le nom du fichier shapefile comme commune
+            shp_path = self.ze_shp_var.get()
+            commune = os.path.splitext(os.path.basename(shp_path))[0]
+
+            # Préparation du dossier de sortie et du nom du document
+            output_dir = os.path.join(OUT_IMG, "Remonter le temps")
             word_filename = "Comparaison_temporelle_Paysage.docx"
             os.makedirs(output_dir, exist_ok=True)
 
-            # --- 1. Lecture des données depuis Excel ---
-            print("Lecture des coordonnées depuis le fichier Excel...")
-            tmp_dir = tempfile.mkdtemp(prefix="excel_tmp_")
-            tmp_file = os.path.join(tmp_dir, "copy.xlsm")
-            shutil.copy2(excel_path, tmp_file)
+            print(f"Coordonnées du centroïde: {lat_dd:.6f}, {lon_dd:.6f}")
 
-            wb = load_workbook(tmp_file, read_only=True, data_only=True, keep_vba=False)
-            ws = wb["0  PYTHON"]
-            coord_raw = str(ws["H5"].value).strip()
-            commune = str(ws["I5"].value).strip()
-            wb.close()
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-
-            lat_dd, lon_dd = (dms_to_dd(s) for s in re.split(r"\s+|,|\t", coord_raw, maxsplit=1))
-            print(f"Commune: {commune}, Coordonnées: {lat_dd:.6f}, {lon_dd:.6f}")
-
-            # --- 2. Capture des images avec Selenium ---
+            # --- Capture des images avec Selenium ---
             print("Lancement de la capture d'images...")
             driver = self._get_or_create_driver()
             if not driver:


### PR DESCRIPTION
## Résumé
- Le bouton **Remonter le temps** se base maintenant sur le centroïde du shapefile choisi par l'utilisateur pour lancer le scraping.
- Suppression de la dépendance au fichier Excel, nettoyage des imports associés.

## Tests
- `python -m py_compile modules/main_app.py`
- `python scripts/smoke_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b313606c60832cb328d5357edddb93