### PR TITLE
Permettre le redimensionnement des panneaux du menu principal

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1110,20 +1110,23 @@ class ExportCartesTab(ttk.Frame):
         self.wiki_query_var = tk.StringVar(value=self.prefs.get("WIKI_QUERY", ""))
 
         # Root layout: left controls, right projects, bottom console
-        root = ttk.Frame(self, style="Header.TFrame")
+        root = ttk.Panedwindow(self, orient=tk.VERTICAL)
         root.pack(fill="both", expand=True)
 
-        left = ttk.Frame(root, style="Card.TFrame")
-        right = ttk.Frame(root, style="Card.TFrame")
-        bottom = ttk.Frame(self, style="Card.TFrame")
+        top = ttk.Panedwindow(root, orient=tk.HORIZONTAL)
+        left = ttk.Frame(top, style="Card.TFrame")
+        right = ttk.Frame(top, style="Card.TFrame")
+        bottom = ttk.Frame(root, style="Card.TFrame")
 
-        left.grid(row=0, column=0, sticky="nsew", padx=6, pady=6)
-        right.grid(row=0, column=1, sticky="nsew", padx=6, pady=6)
-        bottom.pack(fill="both", expand=True, padx=6, pady=(0,6))
+        top.add(left, weight=1)
+        top.add(right, weight=2)
+        root.add(top, weight=3)
+        root.add(bottom, weight=1)
 
-        root.columnconfigure(0, weight=1)
-        root.columnconfigure(1, weight=2)
-        root.rowconfigure(0, weight=1)
+        root.paneconfigure(top, padding=6)
+        root.paneconfigure(bottom, padding=(6, 0, 6, 6))
+        top.paneconfigure(left, padding=6)
+        top.paneconfigure(right, padding=6)
 
         # --- Left: parameters and actions ---
         ttk.Label(left, text="Contexte éco — Paramètres", font=self.font_title).grid(row=0, column=0, columnspan=3, sticky="w", pady=(0,8))


### PR DESCRIPTION
## Résumé
- Ajout d'un agencement via `Panedwindow` pour permettre de redimensionner les sections du menu principal.
- Les panneaux Paramètres, Projets et Console peuvent maintenant être étirés en hauteur ou en largeur.

## Test
- `python -m py_compile modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b31a96a51c832c82aea00924ab2474