### PR TITLE
Ajout du redimensionnement des fenêtres principales

### DIFF
--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1109,21 +1109,20 @@ class ExportCartesTab(ttk.Frame):
         # Wiki query manual override
         self.wiki_query_var = tk.StringVar(value=self.prefs.get("WIKI_QUERY", ""))
 
-        # Root layout: left controls, right projects, bottom console
-        root = ttk.Frame(self, style="Header.TFrame")
-        root.pack(fill="both", expand=True)
+        # Root layout: resizable panes (left/right + console)
+        container = ttk.Panedwindow(self, orient="vertical")
+        container.pack(fill="both", expand=True)
 
-        left = ttk.Frame(root, style="Card.TFrame")
-        right = ttk.Frame(root, style="Card.TFrame")
-        bottom = ttk.Frame(self, style="Card.TFrame")
+        top_pane = ttk.Panedwindow(container, orient="horizontal")
+        container.add(top_pane, weight=3)
 
-        left.grid(row=0, column=0, sticky="nsew", padx=6, pady=6)
-        right.grid(row=0, column=1, sticky="nsew", padx=6, pady=6)
-        bottom.pack(fill="both", expand=True, padx=6, pady=(0,6))
+        bottom = ttk.Frame(container, style="Card.TFrame", padding=6)
+        container.add(bottom, weight=1)
 
-        root.columnconfigure(0, weight=1)
-        root.columnconfigure(1, weight=2)
-        root.rowconfigure(0, weight=1)
+        left = ttk.Frame(top_pane, style="Card.TFrame", padding=6)
+        right = ttk.Frame(top_pane, style="Card.TFrame", padding=6)
+        top_pane.add(left, weight=1)
+        top_pane.add(right, weight=2)
 
         # --- Left: parameters and actions ---
         ttk.Label(left, text="Contexte éco — Paramètres", font=self.font_title).grid(row=0, column=0, columnspan=3, sticky="w", pady=(0,8))


### PR DESCRIPTION
## Résumé
- Permettre de redimensionner les volets dans l'onglet Contexte éco
- Mise en place d'un système de panneaux adaptables (Panedwindow)

## Tests
- `python scripts/smoke_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b31a978fc0832cb5cf56c47e88242b