### PR TITLE
Minimiser les fenêtres Chrome utilisées par Selenium

### DIFF
--- a/Agent.md
+++ b/Agent.md
@@ -15,7 +15,7 @@ Ce qui est inclus dans le dépôt
 
 Pré-requis non-Python
 - QGIS 3.x: requis pour l’onglet “Contexte éco” (export carto via PyQGIS). Par défaut, l’app pointe vers une installation système (variables `QGIS_ROOT`, `QGIS_APP`, `PY_VER` dans `modules/main_app.py`). Pour un isolement maximal, vous pouvez placer une version portable de QGIS dans un sous-dossier du dépôt (ex: `third_party/QGIS`) et ajuster ces variables pour pointer vers ce chemin local.
-- Google Chrome: requis par Selenium. Selenium Manager gère le driver automatiquement. Pour un confinement 100% local, vous pouvez déposer un `chromedriver` dans le dépôt et adapter l’initialisation du `webdriver` afin d’utiliser ce binaire local.
+- Google Chrome: requis par Selenium. Selenium Manager gère le driver automatiquement. Pour un confinement 100% local, vous pouvez déposer un `chromedriver` dans le dépôt et adapter l’initialisation du `webdriver` afin d’utiliser ce binaire local. Les fenêtres Chrome ouvertes par Selenium doivent rester minimisées pour ne pas occuper l’écran.
 
 Règles de contribution (isolation garantie)
 - Ne jamais installer un paquet globalement pour les besoins de l’app. Utiliser exclusivement `.venv` (via `scripts/setup.ps1` ou `.\.venv\Scripts\pip.exe`).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Voir aussi `docs/INSTALL.md` pour les détails et prérequis non‑Python (QGIS/
 ## Pré-requis non‑Python
 
 - QGIS 3.x installé (requis pour l’export via PyQGIS). Les chemins par défaut pointent vers `C:\\Program Files\\QGIS ...`. Pour un confinement total, il est possible d’utiliser une distribution portable de QGIS placée dans le dépôt et d’ajuster `QGIS_ROOT`/`QGIS_APP`/`PY_VER` dans `modules/main_app.py`.
-- Google Chrome (Selenium). Par défaut Selenium Manager gère le driver. Si vous exigez 100% local, placez un `chromedriver` dans le repo et initialisez le WebDriver avec ce binaire.
+- Google Chrome (Selenium). Par défaut Selenium Manager gère le driver. Si vous exigez 100% local, placez un `chromedriver` dans le repo et initialisez le WebDriver avec ce binaire. Les fenêtres Chrome ouvertes par Selenium sont automatiquement minimisées pour ne pas occuper l'écran.
 
 ## Verrouillage des versions (optionnel)
 

--- a/modules/main_app.py
+++ b/modules/main_app.py
@@ -1386,7 +1386,10 @@ class ExportCartesTab(ttk.Frame):
             if not driver:
                 return
             
-            driver.maximize_window()
+            try:
+                driver.minimize_window()
+            except Exception:
+                pass
             images = []
             viewport = (By.CSS_SELECTOR, "div.ol-viewport")
 
@@ -1568,6 +1571,10 @@ class ExportCartesTab(ttk.Frame):
             # options.add_argument('--headless')
             service = Service() # Assurez-vous que chromedriver est dans le PATH
             driver = webdriver.Chrome(service=service, options=options)
+            try:
+                driver.minimize_window()
+            except Exception:
+                pass
             self.shared_driver = driver
             return driver
         except Exception as e:
@@ -1746,6 +1753,10 @@ class ExportCartesTab(ttk.Frame):
             return
 
         try:
+            try:
+                driver.minimize_window()
+            except Exception:
+                pass
             # 1. Wikipedia
             self.after(0, lambda: self.wiki_status_var.set("Scraping Wikipedia..."))
             extracts = self._run_wiki_scrape(driver, query)

--- a/modules/wikipedia_scraper.py
+++ b/modules/wikipedia_scraper.py
@@ -303,7 +303,10 @@ def fetch_wikipedia_info(commune_query: str) -> Tuple[Dict[str, str], webdriver.
             driver = webdriver.Chrome(service=Service(str(local_driver)), options=options)
         else:
             driver = webdriver.Chrome(options=options)
-        driver.maximize_window()
+        try:
+            driver.minimize_window()
+        except Exception:
+            pass
         wait = WebDriverWait(driver, 10)
     except Exception:
         # Impossible d'initialiser Selenium → repli direct HTTP
@@ -435,7 +438,10 @@ def get_wikipedia_extracts(commune_label: str) -> Dict[str, str]:
             driver = webdriver.Chrome(service=Service(str(local_driver)), options=options)
         else:
             driver = webdriver.Chrome(options=options)
-        driver.maximize_window()
+        try:
+            driver.minimize_window()
+        except Exception:
+            pass
         wait = WebDriverWait(driver, 10)
     except Exception:
         # Pas de Selenium: repli MediaWiki API


### PR DESCRIPTION
## Résumé
- les scripts Selenium réduisent maintenant la fenêtre de Chrome dès leur lancement
- la documentation rappelle que ces fenêtres restent minimisées pour ne pas gêner l'utilisateur

## Tests
- `python -m py_compile modules/wikipedia_scraper.py modules/main_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b31bce1814832cbabd7e99f8a7e9e3